### PR TITLE
Added [Feature Request]: blog link needed at blog page #22515

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page-root.component.html
+++ b/core/templates/pages/blog-home-page/blog-home-page-root.component.html
@@ -2,9 +2,9 @@
   <oppia-base-content>
     <navbar-breadcrumb class="blog-homepage">
       <div class="nav navbar-nav oppia-navbar-breadcrumb main-blog-homepage-mobile-breadcrumb">
-        <span class="mx-3 oppia-navbar-breadcrumb-separator"></span>
-        <span class="pt-3 mobile-navbar-blog-homepage">
-          {{ 'I18N_BLOG_HOME_PAGE_BREADCRUMB' | translate }}
+         <span class="mx-3 oppia-navbar-breadcrumb-separator"></span>
+          <span class="pt-3 mobile-navbar-blog-homepage" role="link" (click)="navigateToBlogHome()" style="cursor: pointer;">
+            {{ 'I18N_BLOG_HOME_PAGE_BREADCRUMB' | translate }}
         </span>
       </div>
     </navbar-breadcrumb>

--- a/core/templates/pages/blog-home-page/blog-home-page-root.component.ts
+++ b/core/templates/pages/blog-home-page/blog-home-page-root.component.ts
@@ -25,6 +25,7 @@ import {AccessValidationBackendApiService} from 'pages/oppia-root/routing/access
 import {LoaderService} from 'services/loader.service';
 import {PageHeadService} from 'services/page-head.service';
 import {UserService} from 'services/user.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'oppia-blog-home-page-root',
@@ -39,9 +40,13 @@ export class BlogHomePageRootComponent implements OnDestroy, OnInit {
     private accessValidationBackendApiService: AccessValidationBackendApiService,
     private loaderService: LoaderService,
     private pageHeadService: PageHeadService,
+    private router: Router,
     private translateService: TranslateService,
     private userService: UserService
   ) {}
+    navigateToBlogHome(): void {
+    this.router.navigate(['/blog']);
+  }
 
   ngOnInit(): void {
     this.setPageTitleAndMetaTags();


### PR DESCRIPTION
## Overview

<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #22515.

2. This PR does the following:

* Makes the **BLOG** breadcrumb text on the blog page header clickable, improving navigation.
* Adds a new `navigateToBlogHome()` method in `blog-home-page-root.component.ts` to handle routing back to the `/blog` page using Angular’s `Router`.
* Updates the template in `blog-home-page-root.component.html` to attach the click handler and make the breadcrumb text visually appear clickable.

3. (For bug-fixing PRs only) The original bug occurred because: N/A


## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- [x] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
- [x] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
- [ ] I have written tests for my code.
- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.
-->
##  Proof that changes are correct

### BEFORE

https://github.com/user-attachments/assets/ff5203e2-b60f-474c-8afc-289de478bb42

2a605-2c07-4510-80c2-78faad875fdc)

- The **BLOG** breadcrumb text was not clickable.

### AFTER

https://github.com/user-attachments/assets/f6793324-649d-4190-b699-f4e979401bba


- The **BLOG** breadcrumb is now clickable and routes back to `/blog`.


#### Proof of changes on desktop with slow/throttled network

https://github.com/user-attachments/assets/6ff67c36-f17f-4136-86a5-e70582386039


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
